### PR TITLE
Refac cadastro consistencia

### DIFF
--- a/clients/telegram.client.js
+++ b/clients/telegram.client.js
@@ -1,3 +1,3 @@
 const Telegram = require('telegraf/telegram');
 
-module.exports = new Telegram(process.env.token);
+module.exports = new Telegram(process.env.TOKEN);

--- a/config/default.json
+++ b/config/default.json
@@ -1,4 +1,5 @@
 {
     "db": "mongodb://mongo/vanillaDb",
-    "jwtPrivateKey": "jwtPrivateKey"
+    "jwtPrivateKey": "jwtPrivateKey",
+    "apiUrl": "http://www.itsadeadh2.com/api"
 }

--- a/controllers/oauth.controller.js
+++ b/controllers/oauth.controller.js
@@ -1,5 +1,5 @@
 const winston = require('winston');
-const { oauthService } = require('../services/oauth.service');
+const oauthService = require('../services/oauth.service');
 
 const oauthController = {
   async process(req, res) {

--- a/controllers/oauth.controller.js
+++ b/controllers/oauth.controller.js
@@ -3,11 +3,15 @@ const { oauthService } = require('../services/oauth.service');
 
 const oauthController = {
   async process(req, res) {
-    const { code, state } = req.query;
-    const user = await oauthService.process(state, code);
-    if (!user) return res.status(400).send('Ops! parece que há algo de errado com seu token. Tente novamente.');
-    winston.info(user);
-    return res.send('Pronto, agora voce está autenticado no GitLab!');
+    try {
+      const { code, state } = req.query;
+      const user = await oauthService.process(state, code);
+      if (!user) return res.status(400).send('Ops! parece que há algo de errado com seu token. Tente novamente.');
+      winston.info(user);
+      return res.send('Pronto, agora voce está autenticado no GitLab!');
+    } catch (error) {
+      return res.status(400).send(error);
+    }
   },
 };
 

--- a/controllers/webhook.controller.js
+++ b/controllers/webhook.controller.js
@@ -1,5 +1,5 @@
 const winston = require('winston');
-const webhookService = require('../services/webhook.service');
+const { webhookService } = require('../services/webhook.service');
 
 const webhookController = {
   async notify(req, res) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,19 @@
 version: "3"
-
-services:   
+networks:
+  web:
+    external: true
+services:  
   mongo:
     container_name: mongo 
     image: mongo
-    ports:
-      - 27017:27017
     volumes:
-      - ${PWD}/datadir:/data/db
+      - ${PWD}/datadir:/data/db 
+    networks:
+      - web
+    labels:
+      - traefik.enable=false
+    expose:
+      - "27017"
   api:
     container_name: api
     build:
@@ -17,9 +23,12 @@ services:
       - "TOKEN=${TELEGRAM_BOT_TOKEN}"
       - "CLIENT_ID=${CLIENT_ID}"
       - "CLIENT_SECRET=${CLIENT_SECRET}"
-    ports:
-      - 3000:3000
     volumes:
-      - ${PWD}:/app
+      - ${PWD}:/app    
     depends_on:
       - mongo
+    networks:
+      - web
+    expose:
+      - "3000"
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       - web
     labels:
       - traefik.enable=false
-    expose:
-      - "27017"
+    ports:
+      - 27017:27017
   api:
     container_name: api
     build:

--- a/middleware/telegraf/refreshUserToken.js
+++ b/middleware/telegraf/refreshUserToken.js
@@ -4,9 +4,9 @@
 const moment = require('moment');
 const winston = require('winston');
 const { User } = require('../../models/user.model');
-const { oauthService } = require('../../services/oauth.service');
+const oauthService = require('../../services/oauth.service');
 
-module.exports = async function (ctx, next) {
+module.exports = async (ctx, next) => {
   const user = await User.findById(ctx.from.id);
   if (!user || !user.refresh_token) return next();
   const diff = moment().diff(user.token_expires_in, 'seconds');

--- a/routes/express/index.routes.js
+++ b/routes/express/index.routes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+
+const router = express.Router();
+
+router.get('/', (req, res) => res.send({ name: 'Vanilla The Cat API', description: 'Vanilla the cat telegram bot api' }));
+
+module.exports = router;

--- a/scenes/administraProjetos.js
+++ b/scenes/administraProjetos.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 const { Markup } = require('telegraf');
 const Scene = require('telegraf/scenes/base');
 const { User } = require('../models/user.model');
@@ -14,7 +15,6 @@ administraProjScene.enter(async (ctx) => {
   const user = await User.findById(userId);
   const projects = [];
   user.projects.forEach((project) => {
-    // eslint-disable-next-line no-underscore-dangle
     projects.push(Markup.callbackButton(project.nome, project._id));
   });
   ctx.reply(

--- a/scenes/lesgo.scene.js
+++ b/scenes/lesgo.scene.js
@@ -2,7 +2,7 @@
 const Scene = require('telegraf/scenes/base');
 const { Markup } = require('telegraf');
 const { User } = require('../models/user.model');
-const { oauthService } = require('../services/oauth.service');
+const oauthService = require('../services/oauth.service');
 
 
 const lesgoScene = new Scene('lesgo');

--- a/scenes/novoProjeto.scene.js
+++ b/scenes/novoProjeto.scene.js
@@ -2,6 +2,7 @@
 /* eslint-disable func-names */
 /* eslint-disable no-underscore-dangle */
 const winston = require('winston');
+const config = require('config');
 const Scene = require('telegraf/scenes/base');
 const { Markup } = require('telegraf');
 const axios = require('axios');
@@ -30,7 +31,7 @@ function getNextTwo(startIndex, array) {
 }
 
 const setwebHook = async function (projectId, token) {
-  const hookUrl = 'http://www.itsadeadh2.com/api/gitlabIntegration';
+  const hookUrl = `${config.get('apiUrl')}/gitlabIntegration`;
   let alreadyRegistered = false;
 
   const res = await axios.get(`https://gitlab.com/api/v4/projects/${projectId}/hooks`, { headers: { Authorization: `Bearer ${token}` } });

--- a/scenes/novoProjeto.scene.js
+++ b/scenes/novoProjeto.scene.js
@@ -30,7 +30,7 @@ function getNextTwo(startIndex, array) {
 }
 
 const setwebHook = async function (projectId, token) {
-  const hookUrl = 'http://45.79.228.17:3000/api/gitlabIntegration';
+  const hookUrl = 'http://www.itsadeadh2.com/api/gitlabIntegration';
   let alreadyRegistered = false;
 
   const res = await axios.get(`https://gitlab.com/api/v4/projects/${projectId}/hooks`, { headers: { Authorization: `Bearer ${token}` } });

--- a/services/oauth.service.js
+++ b/services/oauth.service.js
@@ -10,7 +10,7 @@ const { User } = require('../models/user.model');
 exports.oauthService = {
   client_secret: process.env.CLIENT_SECRET,
   client_id: process.env.CLIENT_ID,
-  redirectUri: 'http://45.79.228.17:3000/api/oauth',
+  redirectUri: 'http://www.itsadeadh2.com/api/oauth',
   baseUrl: 'https://gitlab.com/oauth',
 
   generateStateHash(user) {

--- a/services/oauth.service.js
+++ b/services/oauth.service.js
@@ -7,7 +7,7 @@ const axios = require('axios');
 const winston = require('winston');
 const { User } = require('../models/user.model');
 
-exports.oauthService = {
+const oauthService = {
   client_secret: process.env.CLIENT_SECRET,
   client_id: process.env.CLIENT_ID,
   redirectUri: `${config.get('apiUrl')}/oauth`,
@@ -78,3 +78,5 @@ exports.oauthService = {
     }
   },
 };
+
+module.exports = oauthService;

--- a/services/oauth.service.js
+++ b/services/oauth.service.js
@@ -10,7 +10,7 @@ const { User } = require('../models/user.model');
 exports.oauthService = {
   client_secret: process.env.CLIENT_SECRET,
   client_id: process.env.CLIENT_ID,
-  redirectUri: 'http://www.itsadeadh2.com/api/oauth',
+  redirectUri: `${config.get('apiUrl')}/oauth`,
   baseUrl: 'https://gitlab.com/oauth',
 
   generateStateHash(user) {

--- a/services/projects.service.js
+++ b/services/projects.service.js
@@ -5,7 +5,7 @@ const { User } = require('../models/user.model');
 exports.projectsService = {
   client_secret: process.env.CLIENT_SECRET,
   client_id: process.env.CLIENT_ID,
-  redirectUri: 'http://45.79.228.17:3000/api/oauth',
+  redirectUri: 'http://www.itsadeadh2.com/api/oauth',
   baseUrl: 'https://gitlab.com/api/v4',
 
   async getProjectsByUserId(userId) {

--- a/services/projects.service.js
+++ b/services/projects.service.js
@@ -1,11 +1,12 @@
 const winston = require('winston');
+const config = require('config');
 const axios = require('axios');
 const { User } = require('../models/user.model');
 
 exports.projectsService = {
   client_secret: process.env.CLIENT_SECRET,
   client_id: process.env.CLIENT_ID,
-  redirectUri: 'http://www.itsadeadh2.com/api/oauth',
+  redirectUri: `${config.get('apiUrl')}/oauth`,
   baseUrl: 'https://gitlab.com/api/v4',
 
   async getProjectsByUserId(userId) {

--- a/services/projects.service.js
+++ b/services/projects.service.js
@@ -12,7 +12,7 @@ exports.projectsService = {
   async getProjectsByUserId(userId) {
     try {
       const { token } = await User.findById(userId);
-      const projects = await axios.get(`${this.baseUrl}/projects`, { headers: { Authorization: `Bearer ${token}` }, params: { membership: true, simple: true } });
+      const projects = await axios.get(`${this.baseUrl}/projects`, { headers: { Authorization: `Bearer ${token}` }, params: { min_access_level: 40, simple: true } });
       return projects.data;
     } catch (error) {
       return winston.error(error);

--- a/services/webhook.service.js
+++ b/services/webhook.service.js
@@ -15,7 +15,8 @@ exports.webhookService = {
       ['pipeline', this.pipeline],
       ['push', this.push],
       ['merge_request', this.mergeRequest],
-      ['issue', this.issue]
+      ['issue', this.issue],
+      ['note', this.note],
     ]);
     const strategyFn = strategyMap.get(strategy);
     await strategyFn({ data });

--- a/services/webhook.service.js
+++ b/services/webhook.service.js
@@ -73,4 +73,13 @@ exports.webhookService = {
       telegram.sendMessage(user._id, msg, { parse_mode: 'HTML' });
     });
   },
+
+  async note({ data }) {
+    const { project, object_attributes, user } = data;
+    const users = await getUsersByProjectId(project.id);
+    users.forEach((sub) => {
+      const msg = `Hey! O usuario <b>${user.name}</b> acabou de postar um comentário no <i>${object_attributes.noteable_type}</i> do projeto ${project.name}: <i>"${object_attributes.note}"</i> <a href="${object_attributes.url}">Ver na web</a>`;
+      telegram.sendMessage(sub._id, msg, { parse_mode: 'HTML' });
+    });
+  },
 };

--- a/services/webhook.service.js
+++ b/services/webhook.service.js
@@ -68,7 +68,7 @@ exports.webhookService = {
 
   async mergeRequest({ data }) {
     const { project, object_attributes } = data;
-    const users = await this.getUsersByProjectId(project.id);
+    const users = await getUsersByProjectId(project.id);
     users.forEach((user) => {
       const msg = `Hey! O projeto <b>${project.name}</b> acabou de receber um <i>merge request</i> do usuário <b>${user.name}!</b> Para mais detalhes <a href="${object_attributes.url}">clique aqui</a>`;
       telegram.sendMessage(user._id, msg, { parse_mode: 'HTML' });

--- a/startup/database.js
+++ b/startup/database.js
@@ -4,6 +4,6 @@ const config = require('config');
 
 module.exports = () => {
   const db = config.get('db');
-  mongoose.connect(db, { useNewUrlParser: true })
+  mongoose.connect(db, { useNewUrlParser: true, useUnifiedTopology: true })
     .then(() => winston.info(`Connected to ${db} ...`));
 };

--- a/startup/database.js
+++ b/startup/database.js
@@ -4,6 +4,6 @@ const config = require('config');
 
 module.exports = () => {
   const db = config.get('db');
-  mongoose.connect(db)
+  mongoose.connect(db, { useNewUrlParser: true })
     .then(() => winston.info(`Connected to ${db} ...`));
 };

--- a/startup/routes.js
+++ b/startup/routes.js
@@ -2,9 +2,11 @@
 const express = require('express');
 const webHookRoute = require('../routes/express/webhook.routes');
 const oauthRoute = require('../routes/express/oauth.routes');
+const indexRoute = require('../routes/express/index.routes');
 
 module.exports = function (app) {
   app.use(express.json());
   app.use('/api/gitlabIntegration', webHookRoute);
   app.use('/api/oauth', oauthRoute);
+  app.use('/api', indexRoute);
 };


### PR DESCRIPTION
A aplicação estava com um bug onde o usuario conseguia cadastrar duas vezes o mesmo projeto. O projeto não era de fato cadastrado duas vezes no banco, no entanto ainda sim o usuario podia percorrer todo o processo de cadastro de um projeto pra nada. Além disso, para poder desfrutar do bot, o usuario precisa ter um nivel de acesso minimo ao projeto no gitlab para poder adicionar webhooks (alguem com permissao de reporter nao consegue fazer tal coisa), assim sendo nao tinha logica trazer na listagem para o cadastro projetos nos quais o usuario nao tinha permissoes suficientes.

Lidando com os Níveis de acesso - d6c1a1b775cd59f0b1c4146f9234af6b34eeef5f
Lidando com a consistencia da listagem de projetos - e69ade5e736dad75522176c1bb27f180bd06e75c
Pequeno bugfix - 7bf50d385b6bea8d44e9570c4960131e3e7e7699
